### PR TITLE
Add special food with effect

### DIFF
--- a/src/snake/configuration.clj
+++ b/src/snake/configuration.clj
@@ -8,8 +8,8 @@
 (def board-width 30)
 (def board-height 20)
 
-(def base-interval 500)
-(def min-interval 50)
+(def base-interval 200)
+(def min-interval 10)
 (def speed-step 5) ;; every 5 points
 (def speed-increase 10) ;; reduce 10ms each step
 

--- a/src/snake/food.clj
+++ b/src/snake/food.clj
@@ -1,0 +1,78 @@
+(ns snake.food
+  (:require
+   [quil.core :as q]
+   [snake.configuration :refer [board-width board-height]]))
+
+(def food-types
+  {:normal {:color [255 0 0]
+            :score 1}
+
+   :bonus {:color [255 215 0]
+           :score 5
+           :lifetime 3000}
+
+   :slow {:color [0 150 255]
+          :score 1
+          :lifetime 3000
+          :effect :slow}
+
+   :fast {:color [255 0 255]
+          :score 3
+          :lifetime 3000
+          :effect :fast}})
+
+(def effect-durations 5000)
+
+(defn random-food-position []
+  [(rand-int board-width)
+   (rand-int board-height)])
+
+(defn random-special-food-type []
+  (let [r (rand)]
+    (cond
+      (< r 0.85) :bonus
+      (< r 0.95) :slow
+      :else :fast)))
+
+(defn random-empty-cell [snake]
+  (loop []
+    (let [pos (random-food-position)]
+      (if (some #{pos} snake)
+        (recur)
+        pos))))
+
+(defn spawn-food [snake type]
+  (let [pos (random-empty-cell snake)]
+    {:pos pos
+     :type type
+     :spawn-time (q/millis)}))
+
+(defn maybe-spawn-special-food [state]
+  (if (and (nil? (:special-food state))
+           (< (rand) 0.01))
+    (assoc state :special-food
+           (spawn-food (:snake state)
+                       (random-special-food-type)))
+
+    state))
+
+(defn update-special-food-timeout [state]
+  (if-let [sf (:special-food state)]
+    (let [type (:type sf)
+          lifetime (get-in food-types [type :lifetime])]
+      (if (and lifetime
+               (> (- (q/millis) (:spawn-time sf))
+                  lifetime))
+        (assoc state :special-food nil)
+        state))
+    state))
+
+(defn update-effect-timeout [state]
+  (if-let [ef (:active-effect state)]
+    (if (and ef
+             (> (q/millis) (:effect-until state)))
+      (-> state
+          (assoc :active-effect nil
+                 :effect-until 0))
+      state)
+    state))

--- a/src/snake/rendering.clj
+++ b/src/snake/rendering.clj
@@ -1,6 +1,7 @@
 (ns snake.rendering
   (:require
    [snake.configuration :refer [cell-size board-width board-height]]
+   [snake.food :refer [food-types]]
    [quil.core :as q]))
 
 ;; ============================================
@@ -14,8 +15,31 @@
           cell-size
           cell-size))
 
+(defn draw-food [food]
+  (case (:type food)
+
+    :normal
+    (draw-cell (:pos food)
+               (get-in food-types [:normal :color]))
+
+    :bonus
+    (draw-cell (:pos food)
+               (get-in food-types [:bonus :color]))
+
+    :slow
+    (draw-cell (:pos food)
+               (get-in food-types [:slow :color]))
+
+    :fast
+    (draw-cell (:pos food)
+               (get-in food-types [:fast :color]))))
+
 (defn draw-playing [state]
-  (draw-cell (:food state) [255 0 0])
+  (draw-food (:food state))
+
+  (when-let [special-food (:special-food state)]
+    (draw-food special-food))
+
   (doseq [segment (:snake state)]
     (draw-cell segment [0 200 0]))
 

--- a/src/snake/timestep.clj
+++ b/src/snake/timestep.clj
@@ -2,17 +2,30 @@
   (:require
    [snake.configuration :refer [base-interval min-interval speed-step speed-increase]]
    [snake.game-logic :refer [step-snake]]
+   [snake.food :refer [maybe-spawn-special-food update-special-food-timeout update-effect-timeout]]
    [quil.core :as q]))
 
 ;; ============================================
 ;; Fixed Timestep Update
 ;; ============================================
 
-(defn current-interval [score]
-  (let [reduction (* (quot score speed-step)
+(defn effect-interval-reduction [state curr-interval]
+  (if-let [ef (:active-effect state)]
+    (cond
+      (= ef :slow) (quot curr-interval -2)
+      (= ef :fast) (quot curr-interval 2)
+      :else 0)
+    0))
+
+(defn current-interval [state]
+  (let [score (:score state)
+        reduction (* (quot score speed-step)
                      speed-increase)
-        interval (- base-interval reduction)]
-    (max min-interval interval)))
+        interval (- base-interval reduction)
+        effect-reduction (effect-interval-reduction state interval)
+        final-interval (- interval effect-reduction)]
+
+    (max min-interval final-interval)))
 
 (defn update-state [state]
   (case (:mode state)
@@ -20,10 +33,15 @@
     :playing
     (let [now (q/millis)]
       (if (> (- now (:last-move-time state))
-             (current-interval (:score state)))
+             (current-interval state))
+
         (-> state
+            maybe-spawn-special-food
             step-snake
+            update-special-food-timeout
+            update-effect-timeout
             (assoc :last-move-time now))
+
         state))
 
     ;; other modes do not update game logic


### PR DESCRIPTION
- Special food types: 'bonus', 'fast', 'slow'
- Bonus:
  - Worth: 5 scores
  - No effect
  - Lifetime: 3s
- Fast:
  - Worth: 3 scores
  - Effect: increase speed 50%
  - Lifetime: 3s
- Slow:
  - Worth: 1 score
  - Effect: reduce speed 50%
  - Lifetime: 3s

Signed-off-by: Dinh Phu Nguyen <dinhphu.nguyen.20@gmail.com>
